### PR TITLE
add a feature to fully poweroff the disk

### DIFF
--- a/src/main/java/org/luwrain/popups/DisksPopup.java
+++ b/src/main/java/org/luwrain/popups/DisksPopup.java
@@ -39,6 +39,9 @@ public class DisksPopup extends ListPopupBase<DisksPopup.Disk>
 	File activate(Set<Flags> flags);
 	boolean isActivated();
 	boolean deactivate(Set<Flags> flags);
+default boolean poweroff(Set<Flags> flags) {
+return false;
+}
     }
 
     public interface Disks { Disk[] getDisks(Set<Flags> flags); }
@@ -63,7 +66,9 @@ public class DisksPopup extends ListPopupBase<DisksPopup.Disk>
 	    switch(event.getSpecial())
 	    {
 	    case DELETE:
-		return deactivate();
+		if (event.withShift() && event.withControl())
+		return poweroff();
+		else return deactivate();
 	    case ENTER:
 		if (selected() == null)
 		    return false;
@@ -105,6 +110,34 @@ public class DisksPopup extends ListPopupBase<DisksPopup.Disk>
 	}
 	return true;
     }
+
+protected boolean poweroff()
+    {
+	final Disk disk = selected();
+	if (disk == null)
+	    return false;
+	try {
+	    if (disk.isActivated()) {
+	    if (!disk.deactivate(EnumSet.noneOf(Flags.class))) {
+		luwrain.message("Устройство не может быть отключено", Luwrain.MessageType.ERROR);
+		return true;
+}
+}
+
+if (!disk.poweroff(EnumSet.noneOf(Flags.class)))
+		luwrain.message("Устройство не может быть остановлено", Luwrain.MessageType.ERROR);
+else refresh();
+		
+
+	}
+	catch(Throwable e)
+	{
+	    Log.error(LOG_COMPONENT, "unable to poweroff a disk: " + e.getClass().getName() + ": " + e.getMessage());
+	    luwrain.message("Устройство не может быть остановлено", Luwrain.MessageType.ERROR);
+	}
+	return true;
+    }
+
 
     @Override public boolean onOk()
     {

--- a/src/main/java/org/luwrain/popups/DisksPopup.java
+++ b/src/main/java/org/luwrain/popups/DisksPopup.java
@@ -1,5 +1,6 @@
 /*
    Copyright 2012-2021 Michael Pozhidaev <msp@luwrain.org>
+Copyright 2022 Ilya Paschuk <ilusha.paschuk@gmail.com>
 
    This file is part of LUWRAIN.
 


### PR DESCRIPTION
this pr adds the poweroff feature to the luwrain's disk selection popup.

this will allow to fully poweroff the removeable storage device by pressing ctrl+shift+delete.

this feature may be useful for removeable hdds, for which simple unmount is not enough.

this pr adds generic support for this action to the disks popup.

os dependent parts must be modified to really support this.